### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# schedule.interval only affects version updates (e.g. "new release available").
+# Security update PRs are opened as soon as GitHub detects a vulnerability;
+# they are not gated by this schedule.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` matching the aerospike-server standard
- Monthly schedule for GitHub Actions updates, grouped into a single PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)